### PR TITLE
Add Metadata for Init method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 /bin
 /obj
+Template/*.cs
+!Template/TemplateModel.cs
+
+# IDE
+.vs
+.idea

--- a/Template/ClientCPP.tt
+++ b/Template/ClientCPP.tt
@@ -17,11 +17,12 @@ foreach(GrpcService service in s.ServiceArray)
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>(FGrpcMetaData MetaData)
+FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>(<#if(method.ClientStreaming) {#>FGrpcMetaData MetaData<#}#>)
 {
 	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
 	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
 	context->RpcContext = UTurboLinkGrpcManager::Private::CreateRpcClientContext();
+<#if(method.ClientStreaming) {#>
 	for (const auto& metaDataPair : MetaData.MetaData)
 	{
 		context->RpcContext->AddMetadata(
@@ -29,7 +30,6 @@ FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>(FGrpcMetaData 
 			(const char*)StringCast<UTF8CHAR>(*(metaDataPair.Value)).Get()
 		);
 	}
-<#if(method.ClientStreaming) {#>
 	context->Init();
 <#}#>
 	return context->GetHandle();

--- a/Template/ClientCPP.tt
+++ b/Template/ClientCPP.tt
@@ -17,11 +17,18 @@ foreach(GrpcService service in s.ServiceArray)
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>()
+FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>(FGrpcMetaData MetaData)
 {
 	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
 	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
 	context->RpcContext = UTurboLinkGrpcManager::Private::CreateRpcClientContext();
+	for (const auto& metaDataPair : MetaData.MetaData)
+	{
+		context->RpcContext->AddMetadata(
+			(const char*)StringCast<UTF8CHAR>(*(metaDataPair.Key)).Get(),
+			(const char*)StringCast<UTF8CHAR>(*(metaDataPair.Value)).Get()
+		);
+	}
 <#if(method.ClientStreaming) {#>
 	context->Init();
 <#}#>

--- a/Template/ClientH.tt
+++ b/Template/ClientH.tt
@@ -57,7 +57,7 @@ foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
-	FGrpcContextHandle Init<#=method.Name#>();
+	FGrpcContextHandle Init<#=method.Name#>(FGrpcMetaData MetaData);
 
 	UFUNCTION(BlueprintCallable, Category = TurboLink, meta = (AdvancedDisplay = 2))
 	void <#=method.Name#>(FGrpcContextHandle Handle, const <#=method.InputType#>& Request, FGrpcMetaData MetaData = FGrpcMetaData(), float DeadLineSeconds = 0.f);

--- a/Template/ClientH.tt
+++ b/Template/ClientH.tt
@@ -57,7 +57,7 @@ foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
-	FGrpcContextHandle Init<#=method.Name#>(FGrpcMetaData MetaData);
+	FGrpcContextHandle Init<#=method.Name#>(<#if(method.ClientStreaming) {#>FGrpcMetaData MetaData<#}#>);
 
 	UFUNCTION(BlueprintCallable, Category = TurboLink, meta = (AdvancedDisplay = 2))
 	void <#=method.Name#>(FGrpcContextHandle Handle, const <#=method.InputType#>& Request, FGrpcMetaData MetaData = FGrpcMetaData(), float DeadLineSeconds = 0.f);


### PR DESCRIPTION
When the Init method is executed, a connection will be established with the server. When the server receives the request, it can obtain the necessary information from the metadata to process this request.

当执行Init 方法的时候，就会和服务端建立连接，服务端收到请求可以从metadata中获取必要的信息，用于对此请求进行处理。
