### PR TITLE
Simple support of optional fields

### DIFF
--- a/TurboLinkCollection.cs
+++ b/TurboLinkCollection.cs
@@ -485,6 +485,20 @@ namespace protoc_gen_turbolink
 			{
 				for(int i=0; i< protoMessage.OneofDecl.Count; i++)
 				{
+					bool foundOptionals = false;
+					foreach (FieldDescriptorProto field in protoMessage.Field)
+					{
+						if (protoMessage.OneofDecl[i].Name == "_" + field.Name && field.Proto3Optional)
+						{
+							foundOptionals = true;
+                        }
+                    }
+
+					if (foundOptionals)
+					{
+						break;
+					}
+
 					oneofMessageMap.Add(i, new Tuple<int, int>(serviceFile.EnumArray.Count, serviceFile.MessageArray.Count));
 
 					GrpcEnum oneofEnum = new GrpcEnum();
@@ -522,7 +536,7 @@ namespace protoc_gen_turbolink
 					messageField = new GrpcMessageField_Single(field);
 				}
 
-				if (field.HasOneofIndex)
+				if (field.HasOneofIndex && !field.HasProto3Optional)
 				{
 					//add enum field
 					GrpcEnum oneofEnum = serviceFile.EnumArray[oneofMessageMap[field.OneofIndex].Item1];


### PR DESCRIPTION
Basic support for treating optional fields as regular fields allowing access to the value in BluePrint. There is no implementation to determine whether the field's value was defaulted or not.

The documentation states that an optional field will be generated as a "synthetic" Oneof, that only the single optional field will appear in that Oneof, and these "synthetic" Oneofs will appear after the "real" ones. Since the C++ generated code handles the optional functionality under the covers, we can just access that value as we do any regular field. To generate the code as a standard field, we skip Oneof generation output after we find the first Oneof with a single field who's Proto3Optional flag is set to true (per message). Similarly, when the field itself is output, we only do special Oneof handling if that field is not an optional.

It should be possible to add a Has check, but I have not done so as I do not need it at this time.  